### PR TITLE
better error handling when incorrect config file

### DIFF
--- a/novaplugin/plugin.go
+++ b/novaplugin/plugin.go
@@ -288,7 +288,7 @@ func (self *NovaPlugin) init(cfg interface{}) error {
 	err := ReadConfig(cfg, &self.config)
 
 	if err != nil {
-		panic(fmt.Errorf("plugin initalization failed : [%v]", err))
+		return err
 	}
 
 	// testingCollector is a variable that might either be newCollector


### PR DESCRIPTION
Closes #7


Summary of changes:
-change only panic: `panic(fmt.Errorf("plugin initalization failed : [%v]", err))`
for `return fmt.Errorf(err.Error())`, because panic (don't know why causes Unexpected EOF 

Testing done:
-Integration tests

Before: 
`Error loading plugin:`
 `Unexpected EOF `

After: 
`Error loading plugin:`
`GetMetricTypes call error : Cannot find openstack_user in Global Config`