### PR TITLE
gophercloud upgrade, fixes #13

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,129 +1,108 @@
 {
 	"ImportPath": "github.com/intelsdi-x/snap-plugin-collector-nova",
 	"GoVersion": "go1.6",
-	"GodepVersion": "v62",
+	"GodepVersion": "v65",
 	"Deps": [
 		{
 			"ImportPath": "github.com/Sirupsen/logrus",
-			"Comment": "v0.10.0-16-gcd7d1bb",
-			"Rev": "cd7d1bbe41066b6c1f19780f895901052150a575"
+			"Comment": "v0.7.3",
+			"Rev": "55eb11d21d2a31a3cc93838241d04800f52e823d"
+		},
+		{
+			"ImportPath": "github.com/gophercloud/gophercloud",
+			"Rev": "5368725816dfa1fe57af073df5eee113641ac801"
+		},
+		{
+			"ImportPath": "github.com/gophercloud/gophercloud/openstack",
+			"Rev": "5368725816dfa1fe57af073df5eee113641ac801"
+		},
+		{
+			"ImportPath": "github.com/gophercloud/gophercloud/openstack/identity/v2/tenants",
+			"Rev": "5368725816dfa1fe57af073df5eee113641ac801"
+		},
+		{
+			"ImportPath": "github.com/gophercloud/gophercloud/openstack/identity/v2/tokens",
+			"Rev": "5368725816dfa1fe57af073df5eee113641ac801"
+		},
+		{
+			"ImportPath": "github.com/gophercloud/gophercloud/openstack/identity/v3/tokens",
+			"Rev": "5368725816dfa1fe57af073df5eee113641ac801"
+		},
+		{
+			"ImportPath": "github.com/gophercloud/gophercloud/openstack/utils",
+			"Rev": "5368725816dfa1fe57af073df5eee113641ac801"
+		},
+		{
+			"ImportPath": "github.com/gophercloud/gophercloud/pagination",
+			"Rev": "5368725816dfa1fe57af073df5eee113641ac801"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap-plugin-utilities/config",
-			"Rev": "04621af7a3979bcb8aaf08c3b6542b43fe0bf6cf"
+			"Rev": "3c37e3965f3fc2f24714779d3bae7ba7032b87a9"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/plugin",
-			"Comment": "v0.13.0-beta-67-g891c09f",
-			"Rev": "891c09fd7e93aaf7cc0fb976fb91407901fd3843"
+			"Comment": "v0.13.0-beta-77-g5c1177e",
+			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/plugin/cpolicy",
-			"Comment": "v0.13.0-beta-67-g891c09f",
-			"Rev": "891c09fd7e93aaf7cc0fb976fb91407901fd3843"
+			"Comment": "v0.13.0-beta-77-g5c1177e",
+			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/plugin/encoding",
-			"Comment": "v0.13.0-beta-67-g891c09f",
-			"Rev": "891c09fd7e93aaf7cc0fb976fb91407901fd3843"
+			"Comment": "v0.13.0-beta-77-g5c1177e",
+			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/plugin/encrypter",
-			"Comment": "v0.13.0-beta-67-g891c09f",
-			"Rev": "891c09fd7e93aaf7cc0fb976fb91407901fd3843"
+			"Comment": "v0.13.0-beta-77-g5c1177e",
+			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/core",
-			"Comment": "v0.13.0-beta-67-g891c09f",
-			"Rev": "891c09fd7e93aaf7cc0fb976fb91407901fd3843"
+			"Comment": "v0.13.0-beta-77-g5c1177e",
+			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/core/cdata",
-			"Comment": "v0.13.0-beta-67-g891c09f",
-			"Rev": "891c09fd7e93aaf7cc0fb976fb91407901fd3843"
+			"Comment": "v0.13.0-beta-77-g5c1177e",
+			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/core/ctypes",
-			"Comment": "v0.13.0-beta-67-g891c09f",
-			"Rev": "891c09fd7e93aaf7cc0fb976fb91407901fd3843"
+			"Comment": "v0.13.0-beta-77-g5c1177e",
+			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/core/serror",
-			"Comment": "v0.13.0-beta-67-g891c09f",
-			"Rev": "891c09fd7e93aaf7cc0fb976fb91407901fd3843"
+			"Comment": "v0.13.0-beta-77-g5c1177e",
+			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/pkg/ctree",
-			"Comment": "v0.13.0-beta-67-g891c09f",
-			"Rev": "891c09fd7e93aaf7cc0fb976fb91407901fd3843"
+			"Comment": "v0.13.0-beta-77-g5c1177e",
+			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/pkg/schedule",
-			"Comment": "v0.13.0-beta-67-g891c09f",
-			"Rev": "891c09fd7e93aaf7cc0fb976fb91407901fd3843"
+			"Comment": "v0.13.0-beta-77-g5c1177e",
+			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/scheduler/wmap",
-			"Comment": "v0.13.0-beta-67-g891c09f",
-			"Rev": "891c09fd7e93aaf7cc0fb976fb91407901fd3843"
+			"Comment": "v0.13.0-beta-77-g5c1177e",
+			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
 		},
 		{
 			"ImportPath": "github.com/mitchellh/mapstructure",
-			"Rev": "281073eb9eb092240d33ef253c404f1cca550309"
-		},
-		{
-			"ImportPath": "github.com/rackspace/gophercloud",
-			"Comment": "v1.0.0-884-gc54bbac",
-			"Rev": "c54bbac81d19eb4df3ad167764dbb6ff2e7194de"
-		},
-		{
-			"ImportPath": "github.com/rackspace/gophercloud/openstack",
-			"Comment": "v1.0.0-884-gc54bbac",
-			"Rev": "c54bbac81d19eb4df3ad167764dbb6ff2e7194de"
-		},
-		{
-			"ImportPath": "github.com/rackspace/gophercloud/openstack/identity/v2/tenants",
-			"Comment": "v1.0.0-884-gc54bbac",
-			"Rev": "c54bbac81d19eb4df3ad167764dbb6ff2e7194de"
-		},
-		{
-			"ImportPath": "github.com/rackspace/gophercloud/openstack/identity/v2/tokens",
-			"Comment": "v1.0.0-884-gc54bbac",
-			"Rev": "c54bbac81d19eb4df3ad167764dbb6ff2e7194de"
-		},
-		{
-			"ImportPath": "github.com/rackspace/gophercloud/openstack/identity/v3/tokens",
-			"Comment": "v1.0.0-884-gc54bbac",
-			"Rev": "c54bbac81d19eb4df3ad167764dbb6ff2e7194de"
-		},
-		{
-			"ImportPath": "github.com/rackspace/gophercloud/openstack/utils",
-			"Comment": "v1.0.0-884-gc54bbac",
-			"Rev": "c54bbac81d19eb4df3ad167764dbb6ff2e7194de"
-		},
-		{
-			"ImportPath": "github.com/rackspace/gophercloud/pagination",
-			"Comment": "v1.0.0-884-gc54bbac",
-			"Rev": "c54bbac81d19eb4df3ad167764dbb6ff2e7194de"
-		},
-		{
-			"ImportPath": "github.com/rackspace/gophercloud/testhelper",
-			"Comment": "v1.0.0-884-gc54bbac",
-			"Rev": "c54bbac81d19eb4df3ad167764dbb6ff2e7194de"
-		},
-		{
-			"ImportPath": "github.com/rackspace/gophercloud/testhelper/client",
-			"Comment": "v1.0.0-884-gc54bbac",
-			"Rev": "c54bbac81d19eb4df3ad167764dbb6ff2e7194de"
+			"Rev": "d2dd0262208475919e1a362f675cfc0e7c10e905"
 		},
 		{
 			"ImportPath": "github.com/robfig/cron",
-			"Comment": "v1-16-g0f39cf7",
-			"Rev": "0f39cf7ebc65a602f45692f9894bd6a193faf8fa"
-		},
-		{
-			"ImportPath": "golang.org/x/sys/unix",
-			"Rev": "c8bc69bc2db9c57ccf979550bc69655df5039a8a"
+			"Comment": "v1-7-g32d9c27",
+			"Rev": "32d9c273155a0506d27cf73dd1246e86a470997e"
 		},
 		{
 			"ImportPath": "gopkg.in/yaml.v2",

--- a/nova/common.go
+++ b/nova/common.go
@@ -22,7 +22,7 @@ package nova
 import (
 	"fmt"
 
-	"github.com/rackspace/gophercloud"
+	"github.com/gophercloud/gophercloud"
 
 	"github.com/mitchellh/mapstructure"
 )

--- a/nova/v2/requests.go
+++ b/nova/v2/requests.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/intelsdi-x/snap-plugin-collector-nova/nova"
 
-	"github.com/rackspace/gophercloud"
+	"github.com/gophercloud/gophercloud"
 )
 
 type LimitsAbsoluteRespV2 struct {

--- a/novaplugin/collector.go
+++ b/novaplugin/collector.go
@@ -23,10 +23,10 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/rackspace/gophercloud"
-	"github.com/rackspace/gophercloud/openstack"
-	"github.com/rackspace/gophercloud/openstack/identity/v2/tenants"
-	"github.com/rackspace/gophercloud/pagination"
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack"
+	"github.com/gophercloud/gophercloud/openstack/identity/v2/tenants"
+	"github.com/gophercloud/gophercloud/pagination"
 
 	"github.com/intelsdi-x/snap-plugin-collector-nova/nova/v2"
 )
@@ -117,7 +117,10 @@ func newCollector(config Config) (collectorInterface, error) {
 		return nil, err
 	}
 
-	client := openstack.NewIdentityV2(provider)
+	client, err := openstack.NewIdentityV2(provider, gophercloud.EndpointOpts{})
+	if err != nil {
+		return nil, fmt.Errorf("retrieving identity service failed: (%v)", err)
+	}
 	self.Keystone = client
 
 	return self, nil

--- a/novaplugin/plugin.go
+++ b/novaplugin/plugin.go
@@ -38,7 +38,7 @@ const (
 	// Name of plugin
 	Name = "nova-compute"
 	// Version of plugin
-	Version = 2
+	Version = 3
 	// Type of plugin
 	Type = plugin.CollectorPluginType
 )


### PR DESCRIPTION
Fixes #13

Summary of changes:
- Updated library paths to point new version of library
- Updated retrieval of keystone client to match new api
- Updated GoDeps

How to verify it:
- For now Nova Collector should behave identically as without this patch, so run your usual tasks with new version of the plugin.

Testing done:
- Unit Tests
- Manual testing
